### PR TITLE
Dollar-bills enum created

### DIFF
--- a/src/main/java/org/solvd/atm/utils/DollarDenomination.java
+++ b/src/main/java/org/solvd/atm/utils/DollarDenomination.java
@@ -1,11 +1,22 @@
 package org.solvd.atm.utils;
 
 public enum DollarDenomination {
-    $1,
-    $2,
-    $5,
-    $10,
-    $20,
-    $50,
-    $100;
+    $1(1),
+    $2(2),
+    $5(5),
+    $10(10),
+    $20(20),
+    $50(50),
+    $100(100);
+
+    private final int value;
+
+    DollarDenomination(int value){
+        this.value = value;
+    }
+
+    public int getValue(){
+        return this.value;
+    }
+
 }

--- a/src/main/java/org/solvd/atm/utils/DollarDenomination.java
+++ b/src/main/java/org/solvd/atm/utils/DollarDenomination.java
@@ -1,0 +1,11 @@
+package org.solvd.atm.utils;
+
+public enum DollarDenomination {
+    $1,
+    $2,
+    $5,
+    $10,
+    $20,
+    $50,
+    $100;
+}


### PR DESCRIPTION
Basic implementation for an enum that stores the denomination of dollar bills supported by the ATM.

All withdraws and direct deposit (cash, not through transfers from accounts) will handle only USD bills. This enum captures those denominations, and will be used as a type for fields in other ATM classes.